### PR TITLE
Context-menu-add-delete-cells

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,8 +7,8 @@ export interface IContextMenu {
   isContextMenuOpen: boolean;
   locationX: number;
   locationY: number;
-  rowIdx: number;
-  columnIdx: number;
+  // rowIdx: number;
+  // columnIdx: number;
 }
 
 function App() {
@@ -19,8 +19,6 @@ function App() {
     isContextMenuOpen: false,
     locationX: 0,
     locationY: 0,
-    rowIdx: 0,
-    columnIdx: 0,
   });
 
   const handleHeadingChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -4,7 +4,7 @@ import { ICellData } from "./../Spreadsheet";
 
 interface ICell {
   cellData: ICellData;
-  onBlur: () => void;
+  onBlur: (event: React.FocusEvent) => void;
   onChange: (newValue: string) => void;
   onClick: (event: React.MouseEvent) => void;
   onContextMenu: (event: React.MouseEvent) => void;
@@ -18,7 +18,7 @@ interface ICell {
   onDragLeave?: (event: React.DragEvent<HTMLInputElement>) => void;
   onDragOver?: (event: React.DragEvent<HTMLInputElement>) => void;
   onDrop?: (event: React.DragEvent<HTMLInputElement>) => void;
-  onFocus: () => void;
+  onFocus: (event: React.FocusEvent<HTMLInputElement>) => void;
   onKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
   onMouseDown: (event: React.MouseEvent) => void;
   onMouseMove: () => void;

--- a/src/components/CellWrapper/CellWrapper.tsx
+++ b/src/components/CellWrapper/CellWrapper.tsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 
 interface CellWrapperProps {
   children: React.ReactNode;
+  onClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
   onContextMenu?: (event: React.MouseEvent<HTMLDivElement>) => void;
   onDrag?: (event: React.DragEvent<HTMLDivElement>) => void;
   onDragEnd?: (event: React.DragEvent<HTMLDivElement>) => void;
@@ -15,6 +16,7 @@ interface CellWrapperProps {
 
 const CellWrapper = ({
   children,
+  onClick,
   onContextMenu,
   onDrag,
   onDragEnd,
@@ -27,6 +29,7 @@ const CellWrapper = ({
 }: CellWrapperProps) => {
   return (
     <CellWrapperStyledOne
+      onClick={onClick}
       onContextMenu={onContextMenu}
       onDrag={onDrag}
       onDragEnd={onDragEnd}

--- a/src/components/CellWrapper/CellWrapper.tsx
+++ b/src/components/CellWrapper/CellWrapper.tsx
@@ -11,6 +11,7 @@ interface CellWrapperProps {
   onDragLeave?: (event: React.DragEvent<HTMLDivElement>) => void;
   onDragOver?: (event: React.DragEvent<HTMLDivElement>) => void;
   onDrop?: (event: React.DragEvent<HTMLDivElement>) => void;
+  onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void;
   onMouseOver?: (event: React.MouseEvent<HTMLDivElement>) => void;
 }
 
@@ -25,6 +26,7 @@ const CellWrapper = ({
   onDragLeave,
   onDragOver,
   onDrop,
+  onFocus,
   onMouseOver,
 }: CellWrapperProps) => {
   return (
@@ -39,6 +41,7 @@ const CellWrapper = ({
       onDragLeave={onDragLeave}
       onDragOver={onDragOver}
       onDrop={onDrop}
+      onFocus={onFocus}
       onMouseOver={onMouseOver}
     >
       {children}

--- a/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/components/ContextMenu/ContextMenu.tsx
@@ -29,8 +29,8 @@ interface ContextMenuProps {
     rowIdxStart,
     rowsCount,
   }: RowsToDelete) => void;
-  selectionStartCell: SelectedCells[ "selectionStartCell" ];
-  selectionEndCell: SelectedCells[ "selectionEndCell" ];
+  selectionStartCell: SelectedCells["selectionStartCell"];
+  selectionEndCell: SelectedCells["selectionEndCell"];
   left: number;
   top: number;
 }
@@ -60,13 +60,14 @@ const ContextMenu = ({
     const hasOneColumn = columnsCount === 1;
     const hasOneOrMoreColumns = columnsCount >= 1;
     if (hasZeroColumns) return;
-    if (hasZeroColumns) { 
-      console.log("hasZeroColumns")
-    }
+
     return (
       <MenuItem
         icon={iconAdd}
-        onClick={() => addColumns({ columnIdx: columnIdxStart, columnsCount })}
+        onClick={() => {
+          console.log("<MenuItem> onClick (addColumns)");
+          addColumns({ columnIdx: columnIdxStart, columnsCount });
+        }}
       >
         {hasOneOrMoreColumns && (
           <ContextMenuItemTextStyled>
@@ -152,7 +153,11 @@ const ContextMenu = ({
   };
 
   return (
-    <ContextMenuStyled left={left} onContextMenu={() => { }} top={top}>
+    <ContextMenuStyled
+      left={left}
+      onContextMenu={(event: React.MouseEvent) => event?.preventDefault()}
+      top={top}
+    >
       {addColumnsMenuItem()}
       {addRowsMenuItem()}
       {horizontalLine({ color: "lightgray", margin: "2px 4px" })}

--- a/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/components/ContextMenu/ContextMenu.tsx
@@ -20,8 +20,8 @@ interface ContextMenuProps {
   addColumns: ({ columnIdx, columnsCount }: ColumnsToAdd) => void;
   addRows: ({ rowIdx, rowsCount }: RowsToAdd) => void;
   deleteSelectedColumns: ({
-    columnIdxEnd,
     columnIdxStart,
+    columnIdxEnd,
     columnsCount,
   }: ColumnsToDelete) => void;
   deleteSelectedRows: ({
@@ -55,11 +55,14 @@ const ContextMenu = ({
   );
 
   const addColumnsMenuItem = () => {
-    const columnsCount = calculateColumnCount({ columnIdxEnd, columnIdxStart });
+    const columnsCount = calculateColumnCount({ columnIdxStart, columnIdxEnd });
     const hasZeroColumns = columnsCount === 0;
     const hasOneColumn = columnsCount === 1;
     const hasOneOrMoreColumns = columnsCount >= 1;
     if (hasZeroColumns) return;
+    if (hasZeroColumns) { 
+      console.log("hasZeroColumns")
+    }
     return (
       <MenuItem
         icon={iconAdd}
@@ -149,7 +152,7 @@ const ContextMenu = ({
   };
 
   return (
-    <ContextMenuStyled left={left} onContextMenu={() => {}} top={top}>
+    <ContextMenuStyled left={left} onContextMenu={() => { }} top={top}>
       {addColumnsMenuItem()}
       {addRowsMenuItem()}
       {horizontalLine({ color: "lightgray", margin: "2px 4px" })}

--- a/src/components/ContextMenu/MenuItem/MenuItem.tsx
+++ b/src/components/ContextMenu/MenuItem/MenuItem.tsx
@@ -14,13 +14,7 @@ const MenuItem = ({
   onClick,
 }: MenuItemProps) => {
   return (
-    /* onContextMenu prop is here to stop operating system context menu from appearing when user right clicks on MenuItem component. */
-    <MenuItemStyled
-      onClick={onClick}
-      // onContextMenu={(event: React.MouseEvent) => {
-      //   event?.preventDefault();
-      // }}
-    >
+    <MenuItemStyled onClick={onClick}>
       <div style={{ marginRight: iconMarginRight }}>{icon}</div>
       {children}
     </MenuItemStyled>

--- a/src/components/Spreadsheet/Spreadsheet.tsx
+++ b/src/components/Spreadsheet/Spreadsheet.tsx
@@ -167,7 +167,7 @@ const Spreadsheet = ({
       selectionEndCell: { rowIdx: null, columnIdx: null },
       allSelectedCells: [],
     });
-    if (contextMenu.isContextMenuOpen) { 
+    if (contextMenu.isContextMenuOpen) {
       setContextMenu({ ...contextMenu, isContextMenuOpen: false });
     }
   };
@@ -1093,6 +1093,9 @@ const Spreadsheet = ({
                   {/* Add the rest of row items.  */}
                   <CellWrapper
                     key={`cell-wrapper-${rowIdx}/${columnIdx}`}
+                    onClick={(event: React.MouseEvent) =>
+                      handleCellClick(columnIdx, event, rowIdx)
+                    }
                     onContextMenu={(event: React.MouseEvent<HTMLDivElement>) =>
                       handleCellClick(columnIdx, event, rowIdx)
                     }

--- a/src/components/Spreadsheet/Spreadsheet.tsx
+++ b/src/components/Spreadsheet/Spreadsheet.tsx
@@ -151,7 +151,15 @@ const Spreadsheet = ({
     });
   };
 
-  const handleCellBlur = () => {
+  const handleCellBlur = ({
+    rowIdx,
+    columnIdx,
+    event,
+  }: {
+    rowIdx: number;
+    columnIdx: number;
+    event: React.FocusEvent;
+  }) => {
     // Change all the selectedCells isEditing and isFocused values to false.
     const newSpreadsheet = spreadsheetState.map((row) => {
       const newRow = row.map((cell: ICellData) => {
@@ -161,19 +169,36 @@ const Spreadsheet = ({
     });
     setSpreadsheetState(newSpreadsheet);
     handleDBUpdate(newSpreadsheet);
+
+    // If click target is not a cell, then clear the selectedCells state.
+    const spreadSheetRefCellKey = formatKeyOfSpreadsheetRefMap(
+      columnIdx,
+      rowIdx
+    );
+
+    if (contextMenu.isContextMenuOpen) {
+      return;
+    }
+
     setSelectedCells({
       previousCell: { rowIdx: null, columnIdx: null },
       selectionStartCell: { rowIdx: null, columnIdx: null },
       selectionEndCell: { rowIdx: null, columnIdx: null },
       allSelectedCells: [],
     });
-    if (contextMenu.isContextMenuOpen) {
-      setContextMenu({ ...contextMenu, isContextMenuOpen: false });
-    }
   };
 
   // When "Tab" key is pressed, next cell gets focus an handleCellFocus is called.
-  const handleCellFocus = (columnIdx: number, rowIdx: number) => {
+  const handleCellFocus = ({
+    rowIdx,
+    columnIdx,
+    event,
+  }: {
+    rowIdx: number;
+    columnIdx: number;
+    event: React.FocusEvent<HTMLInputElement>;
+  }) => {
+    event.stopPropagation();
     changeCellState({
       columnIdx,
       rowIdx,
@@ -218,18 +243,6 @@ const Spreadsheet = ({
     columnIdx: number;
     event: React.MouseEvent;
   }) => {
-    console.log(
-      "cell's onClick got called --> ",
-      columnIdx,
-      "/",
-      rowIdx,
-      event
-    );
-    // If context menu is open, then close it.
-    if (contextMenu.isContextMenuOpen) {
-      setContextMenu({ ...contextMenu, isContextMenuOpen: false });
-    }
-
     // Update spreadsheet state: the cell selected is set to true, the rest of the cells selected value will be false.
     const spreadSheetCopy = [...spreadsheetState];
     const newSpreadSheetState = spreadSheetCopy.map((row, rowI) => {
@@ -264,13 +277,7 @@ const Spreadsheet = ({
   }) => {
     event.preventDefault();
     event.stopPropagation();
-    console.log(
-      "cell's onContextMenu got called --> ",
-      columnIdx,
-      "/",
-      rowIdx,
-      event
-    );
+    const currentCell = { rowIdx, columnIdx };
 
     setContextMenu({
       isContextMenuOpen: true,
@@ -278,14 +285,13 @@ const Spreadsheet = ({
       locationY: event.clientY,
     });
 
-    const currentCell = { rowIdx, columnIdx };
     setSelectedCells({
       previousCell: currentCell,
       selectionStartCell: currentCell,
       selectionEndCell: currentCell,
       allSelectedCells: [currentCell],
     });
-    moveFocusTo(columnIdx, rowIdx);
+    setIsSelecting(false);
   };
 
   const handleDoubleClick = ({
@@ -317,8 +323,8 @@ const Spreadsheet = ({
     dt.setData("text/plain", spreadsheetState[rowIdx][columnIdx].value!);
     event.dataTransfer.effectAllowed = "move";
     event.dataTransfer.dropEffect = "move";
-    console.log("drag start");
-    console.log("onDragStart event.dataTransfer ---->", event.dataTransfer);
+    // console.log("drag start");
+    // console.log("onDragStart event.dataTransfer ---->", event.dataTransfer);
   };
 
   const handleCellWrapperDragEnd = ({
@@ -330,7 +336,7 @@ const Spreadsheet = ({
     columnIdx: number;
     event: React.DragEvent<HTMLDivElement>;
   }) => {
-    console.log(`onDragEnd ---> columnIdx: ${columnIdx} rowIdx: ${rowIdx}`);
+    // console.log(`onDragEnd ---> columnIdx: ${columnIdx} rowIdx: ${rowIdx}`);
     // console.log(
     //   `onDragEnd event.dataTransfer.dropEffect ---->`,
     //   event.dataTransfer.dropEffect
@@ -338,7 +344,7 @@ const Spreadsheet = ({
     // If cell was dragged to a cell that is not droppable, then early return.
     if (event.dataTransfer.dropEffect === "none") return;
     // If the cell was dropped on the same cell, then don't change the cell state.
-    console.log("currentCell on DragEnd ---->", currentCell);
+    // console.log("currentCell on DragEnd ---->", currentCell);
     if (currentCell.columnIdx === columnIdx && currentCell.rowIdx === rowIdx)
       return;
 
@@ -359,9 +365,9 @@ const Spreadsheet = ({
     event: React.DragEvent<HTMLDivElement>;
   }) => {
     const data = event.dataTransfer.getData("text/plain");
-    console.log("onDrop columnIdx ---->", columnIdx);
-    console.log("onDrop rowIdx ---->", rowIdx);
-    console.log("onDrop data ---->", data);
+    // console.log("onDrop columnIdx ---->", columnIdx);
+    // console.log("onDrop rowIdx ---->", rowIdx);
+    // console.log("onDrop data ---->", data);
     setCurrentCell({ columnIdx, rowIdx });
     changeCellState({
       rowIdx,
@@ -426,13 +432,22 @@ const Spreadsheet = ({
     if (event.key.length === 1) {
       if (currentCell.isFocused && !currentCell.isEditing) {
         // Clear the cell value.
-        console.log("isEditing is false and event.key is --->", event.key);
+        // console.log("isEditing is false and event.key is --->", event.key);
         changeCellState({
           rowIdx,
           columnIdx,
           cellUpdate: { isEditing: true, isFocused: true, value: "" },
         });
       }
+    }
+
+    // Close context menu if it is open and the user IS typing.
+    if (currentCell.isFocused && currentCell.isEditing) {
+      closeContextMenu();
+    }
+    // Close context menu if it is open and the user IS NOT typing.
+    if (currentCell.isFocused && !currentCell.isEditing) {
+      closeContextMenu();
     }
 
     if (event.key === "Enter") {
@@ -518,7 +533,7 @@ const Spreadsheet = ({
     }
   };
 
-  const handleMouseDown = ({
+  const handleOnMouseDown = ({
     rowIdx,
     columnIdx,
     event,
@@ -528,14 +543,14 @@ const Spreadsheet = ({
     event: React.MouseEvent;
   }) => {
     event.preventDefault();
-    console.log("cell's onMouseDown called on --->", { rowIdx, columnIdx });
-    setIsSelecting(true);
     moveFocusTo(columnIdx, rowIdx);
-    const cell = spreadsheetState[rowIdx][columnIdx];
-    // If the cell is already selected, then don't update the cell state.
-    if (cell.isFocused) return;
-
+    setIsSelecting(true);
     const currentCell = { rowIdx, columnIdx };
+    // If the current cell is already selected, then don't update the selectedCells state.
+    if (arrayIncludesObject(selectedCells.allSelectedCells, currentCell)) {
+      console.log("current cell is already selected");
+      return;
+    }
     setSelectedCells({
       previousCell: currentCell,
       selectionStartCell: currentCell,
@@ -845,7 +860,7 @@ const Spreadsheet = ({
       // TODO: add if statements to make sure all the for loops don't run all the time.
       // Moving downwards and/or rightwards.
       for (let row = selectionStartCell.rowIdx; row! <= cell.rowIdx!; row!++) {
-        console.log("Moving downwards and/or rightwards.");
+        // console.log("Moving downwards and/or rightwards.");
         for (
           let col = selectionStartCell.columnIdx;
           col! <= cell.columnIdx!;
@@ -857,7 +872,7 @@ const Spreadsheet = ({
 
       // Moving downwards and/or leftwards.
       for (let row = selectionStartCell.rowIdx; row! <= cell.rowIdx!; row!++) {
-        console.log("Moving downwards and/or leftwards.");
+        // console.log("Moving downwards and/or leftwards.");
         for (
           let col = selectionStartCell.columnIdx;
           col! >= cell.columnIdx!;
@@ -870,7 +885,7 @@ const Spreadsheet = ({
       // Moving upwards (column) and/or leftwards (row).
       for (let row = selectionStartCell.rowIdx; row! >= cell.rowIdx!; row!--) {
         if (selectionStartCell.columnIdx! >= cell.columnIdx!) {
-          console.log("Moving row left");
+          // console.log("Moving row left");
           for (
             let col = selectionStartCell.columnIdx;
             col! >= cell.columnIdx!;
@@ -879,7 +894,7 @@ const Spreadsheet = ({
             selectedCells.push({ rowIdx: row, columnIdx: col });
           }
         } else if (selectionStartCell.columnIdx! <= cell.columnIdx!) {
-          console.log("Moving row right");
+          // console.log("Moving row right");
           for (
             let col = selectionStartCell.columnIdx;
             col! <= cell.columnIdx!;
@@ -906,7 +921,6 @@ const Spreadsheet = ({
     columnIdx: number;
     rowIdx: number;
   }) => {
-    console.log("cell's onMouseUp called on cell --->", { rowIdx, columnIdx });
     setIsSelecting(false);
   };
 
@@ -946,7 +960,6 @@ const Spreadsheet = ({
 
   /** Add "columnsCount" number of new empty columns at the columnIdxStart. */
   const addColumns = ({ columnIdx, columnsCount }: ColumnsToAdd) => {
-    console.log("addColumns, columnIdxStart --->", columnIdx);
     // Loop over the spreadSheetCopy and for each row, add "x" new empty cells at the columnIdxStart.
     const newSpreadSheetState = spreadsheetState.map((row, rowIndex) => {
       const startChunkOfTheRow = row.slice(0, columnIdx!);
@@ -979,6 +992,12 @@ const Spreadsheet = ({
     setSpreadsheetState(newSpreadSheetState);
     handleDBUpdate(newSpreadSheetState);
     setContextMenu({ ...contextMenu, isContextMenuOpen: false });
+    setSelectedCells({
+      previousCell: { rowIdx: null, columnIdx: null },
+      selectionStartCell: { rowIdx: null, columnIdx: null },
+      selectionEndCell: { rowIdx: null, columnIdx: null },
+      allSelectedCells: [],
+    });
   };
 
   // TODO: fix this
@@ -1003,6 +1022,12 @@ const Spreadsheet = ({
     setSpreadsheetState(newSpreadSheetState);
     handleDBUpdate(newSpreadSheetState);
     setContextMenu({ ...contextMenu, isContextMenuOpen: false });
+    setSelectedCells({
+      previousCell: { rowIdx: null, columnIdx: null },
+      selectionStartCell: { rowIdx: null, columnIdx: null },
+      selectionEndCell: { rowIdx: null, columnIdx: null },
+      allSelectedCells: [],
+    });
   };
 
   /** Add "rowsCount" number of new empty rows at the rowIdxStart. */
@@ -1041,6 +1066,12 @@ const Spreadsheet = ({
     setSpreadsheetState(newSpreadsheet);
     handleDBUpdate(newSpreadsheet);
     setContextMenu({ ...contextMenu, isContextMenuOpen: false });
+    setSelectedCells({
+      previousCell: { rowIdx: null, columnIdx: null },
+      selectionStartCell: { rowIdx: null, columnIdx: null },
+      selectionEndCell: { rowIdx: null, columnIdx: null },
+      allSelectedCells: [],
+    });
   };
 
   /** Delete the selected rows from the spreadsheet. */
@@ -1049,9 +1080,7 @@ const Spreadsheet = ({
     rowIdxStart,
     rowsCount,
   }: RowsToDelete) => {
-    console.log("deleteSelectedRows, rowIdxStart --->", rowIdxStart);
     const firstChunkOfRows = spreadsheetState.slice(0, rowIdxStart!);
-    console.log("deleteSelectedRows, firstChunkOfRows --->", firstChunkOfRows);
     const endChunkOfRows = [];
     for (let i = rowIdxEnd! + 1; i < spreadsheetState.length; i++) {
       endChunkOfRows.push(
@@ -1064,6 +1093,12 @@ const Spreadsheet = ({
     setSpreadsheetState(newSpreadsheet);
     handleDBUpdate(newSpreadsheet);
     setContextMenu({ ...contextMenu, isContextMenuOpen: false });
+    setSelectedCells({
+      previousCell: { rowIdx: null, columnIdx: null },
+      selectionStartCell: { rowIdx: null, columnIdx: null },
+      selectionEndCell: { rowIdx: null, columnIdx: null },
+      allSelectedCells: [],
+    });
   };
 
   useEffect(() => {
@@ -1108,7 +1143,7 @@ const Spreadsheet = ({
               {row.map((column, columnIdx) => (
                 <CellHeader
                   key={`cell-header-${rowIdx}/${columnIdx}`}
-                  value={`${columnIdx + 1}C`}
+                  value={`C${columnIdx + 1}`}
                 />
               ))}
             </div>
@@ -1123,18 +1158,26 @@ const Spreadsheet = ({
                     <CellHeader
                       isFirstColumnCell
                       key={`row-header-${rowIdx}/${columnIdx}`}
-                      value={`${rowIdx + 1}R`}
+                      value={`R${rowIdx + 1}`}
                     />
                   )}
                   {/* Add the rest of row items.  */}
                   <CellWrapper
                     key={`cell-wrapper-${rowIdx}/${columnIdx}`}
-                    onClick={(event: React.MouseEvent<HTMLDivElement>) =>
-                      handleCellClick({ rowIdx, columnIdx, event })
-                    }
+                    onClick={(event: React.MouseEvent<HTMLDivElement>) => {
+                      console.log(
+                        "<CellWrapper> %conClick called",
+                        "color: yellow"
+                      );
+                      handleCellClick({ rowIdx, columnIdx, event });
+                    }}
                     onContextMenu={(
                       event: React.MouseEvent<HTMLDivElement>
                     ) => {
+                      console.log(
+                        "<CellWrapper> %conContextMenu called",
+                        "color: #0084c8"
+                      );
                       handleCellOnContextMenu({ rowIdx, columnIdx, event });
                     }}
                     onDragEnd={(event: React.DragEvent<HTMLDivElement>) =>
@@ -1149,6 +1192,13 @@ const Spreadsheet = ({
                     }}
                     onDrop={(event) => {
                       handleCellWrapperDrop({ rowIdx, columnIdx, event });
+                    }}
+                    onFocus={(event: React.FocusEvent<HTMLInputElement>) => {
+                      console.log(
+                        "<CellWrapper> %conFocus called",
+                        "color:green"
+                      );
+                      handleCellFocus({ rowIdx, columnIdx, event });
                     }}
                     onMouseOver={(event: any) => {
                       if (event.target !== event.currentTarget) {
@@ -1169,18 +1219,33 @@ const Spreadsheet = ({
                         value: column.value,
                       }}
                       key={`cell-${rowIdx}/${columnIdx}`}
-                      onBlur={handleCellBlur}
+                      onBlur={(event: React.FocusEvent) => {
+                        console.log("<Cell> %conBlur called", "color: red");
+                        handleCellBlur({ rowIdx, columnIdx, event });
+                      }}
                       onChange={(newValue) => {
+                        console.log("<Cell> onChange called");
                         handleCellValueChange({ rowIdx, columnIdx, newValue });
                       }}
-                      onClick={(event: React.MouseEvent) =>
-                        handleCellClick({ rowIdx, columnIdx, event })
-                      }
-                      onContextMenu={(event: React.MouseEvent) =>
-                        handleCellOnContextMenu({ rowIdx, columnIdx, event })
-                      }
-                      onCopy={() => handleOnCopy(columnIdx, rowIdx)}
-                      onCut={() => handleOnCut(columnIdx, rowIdx)}
+                      onClick={(event: React.MouseEvent) => {
+                        console.log("<Cell> %conClick called", "color: yellow");
+                        handleCellClick({ rowIdx, columnIdx, event });
+                      }}
+                      onContextMenu={(event: React.MouseEvent) => {
+                        console.log(
+                          "<Cell> %conContextMenu called",
+                          "color: #0084c8"
+                        );
+                        handleCellOnContextMenu({ rowIdx, columnIdx, event });
+                      }}
+                      onCopy={() => {
+                        console.log("<Cell> onCopy called");
+                        handleOnCopy(columnIdx, rowIdx);
+                      }}
+                      onCut={() => {
+                        console.log("<Cell> onCut called");
+                        handleOnCut(columnIdx, rowIdx);
+                      }}
                       onDoubleClick={() =>
                         handleDoubleClick({ rowIdx, columnIdx })
                       }
@@ -1191,14 +1256,27 @@ const Spreadsheet = ({
                         // More info here: https://stackoverflow.com/a/44049369/10029397
                         event.preventDefault();
                       }}
-                      onFocus={() => handleCellFocus(columnIdx, rowIdx)}
+                      onFocus={(event: React.FocusEvent<HTMLInputElement>) => {
+                        console.log("<Cell> %conFocus called", "color: green");
+                        handleCellFocus({ rowIdx, columnIdx, event });
+                      }}
                       onKeyDown={(
                         event: React.KeyboardEvent<HTMLInputElement>
-                      ) => handleKeyDown(columnIdx, event, rowIdx)}
-                      onMouseDown={(event: React.MouseEvent) => {
-                        handleMouseDown({ rowIdx, columnIdx, event });
+                      ) => {
+                        console.log("<Cell> onKeyDown called");
+                        handleKeyDown(columnIdx, event, rowIdx);
                       }}
-                      onMouseMove={() => handleMouseMove({ rowIdx, columnIdx })}
+                      onMouseDown={(event: React.MouseEvent) => {
+                        console.log(
+                          "<Cell> %conMouseDown called",
+                          "color: orange"
+                        );
+                        handleOnMouseDown({ rowIdx, columnIdx, event });
+                      }}
+                      onMouseMove={() => {
+                        // console.log("<Cell> onMouseMove called");
+                        handleMouseMove({ rowIdx, columnIdx });
+                      }}
                       onMouseOver={(
                         event: React.MouseEvent<HTMLInputElement>
                       ) => {
@@ -1207,9 +1285,16 @@ const Spreadsheet = ({
                       onMouseUp={(
                         event: React.MouseEvent<HTMLInputElement>
                       ) => {
+                        console.log(
+                          "<Cell> %conMouseUp called",
+                          "color: purple"
+                        );
                         handleOnMouseUp({ rowIdx, columnIdx });
                       }}
-                      onPaste={() => handleOnPaste(columnIdx, rowIdx)}
+                      onPaste={() => {
+                        console.log("<Cell> onPaste called");
+                        handleOnPaste(columnIdx, rowIdx);
+                      }}
                       ref={(element: HTMLInputElement) =>
                         handleAddRef(element, columnIdx, rowIdx)
                       }


### PR DESCRIPTION
- When right click on cell's context menu don't open OS's context menu.
- Update cell and column header to start with R or C.
- On keyDown close context menu when cell is focused and user is typing.
- Also lose context menu when cell is focused and user is not typing.